### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Docker Build and Push
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/degagne/docker-aws-lambda/security/code-scanning/1](https://github.com/degagne/docker-aws-lambda/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (applies to all jobs) or at the job level (applies only to the specified job). The minimal starting point recommended by CodeQL is `contents: read`, which allows the workflow to read repository contents but not write to them. This is sufficient for checking out code and building/pushing Docker images, as shown in the workflow. The change should be made at the top level of the workflow file, immediately after the `name:` declaration and before the `on:` block, or inside the job definition. The best practice is to add it at the root level so all jobs inherit the least privilege unless otherwise specified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
